### PR TITLE
Add fan-only thermostat mode for Mitsubishi mini splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default thermostat temperature units to Fahrenheit.
 
 ### Fixed
-- Skip APPLICATION devices to avoid connection errors.
+- Handle APPLICATION device types as thermostats to support app-based mini splits.
 
 See the [roadmap](https://homebridge-alexa-smarthome.canny.io/) for up-to-date, unreleased work in progress.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-08-16
+
+### Changed
+- Default thermostat temperature units to Fahrenheit.
+
+### Fixed
+- Skip APPLICATION devices to avoid connection errors.
+
 See the [roadmap](https://homebridge-alexa-smarthome.canny.io/) for up-to-date, unreleased work in progress.
 
 ## [2.3.0] - 2025-04-12
@@ -253,36 +261,7 @@ See the [roadmap](https://homebridge-alexa-smarthome.canny.io/) for up-to-date, 
 
 - Support for outlets i.e. smart plugs.
 
-[unreleased]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.3.0...HEAD
-[2.3.0]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.2.1...v2.3.0
-[2.2.1]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.2.0...v2.2.1
-[2.2.0]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.1.5...v2.2.0
-[2.1.5]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.1.4...v2.1.5
-[2.1.4]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.1.3...v2.1.4
-[2.1.3]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.1.2...v2.1.3
-[2.1.2]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.1.1...v2.1.2
-[2.1.1]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.1.0...v2.1.1
-[2.1.0]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.8...v2.1.0
-[2.0.8]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.7...v2.0.8
-[2.0.7]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.6...v2.0.7
-[2.0.6]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.5...v2.0.6
-[2.0.5]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.4...v2.0.5
-[2.0.4]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.3...v2.0.4
-[2.0.3]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.2...v2.0.3
-[2.0.2]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.1...v2.0.2
-[2.0.1]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v1.0.3...v2.0.0
-[1.0.3]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.2.1...v1.0.0
-[0.2.1]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.1.2...v0.2.0
-[0.1.2]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.0.19...v0.1.0
-[0.0.19]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.0.18...v0.0.19
-[0.0.18]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.0.17...v0.0.18
-[0.0.17]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.0.16...v0.0.17
-[0.0.16]: https://github.com/joeyhage/homebridge-spotify-speaker/compare/v0.0.15...v0.0.16
-[0.0.15]: https://github.com/joeyhage/homebridge-spotify-speaker/releases/tag/v0.0.15
+[unreleased]: https://github.com/joeyhage/homebridge-alexa-smarthome/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/joeyhage/homebridge-alexa-smarthome/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/joeyhage/homebridge-alexa-smarthome/releases/tag/v1.0.0
+[0.0.15]: https://github.com/joeyhage/homebridge-alexa-smarthome/releases/tag/v0.0.15

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-ac-test",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-ac-test",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "alexa-cookie2": "^5.0.2",
@@ -46,7 +46,7 @@
       },
       "funding": {
         "type": "github",
-        "url": "https://github.com/sponsors/jakef14"
+        "url": "https://github.com/sponsors/joeyhage"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
   "displayName": "Homebridge AC Test",
   "name": "homebridge-ac-test",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Homebridge plugin that can control smart home devices connected to Alexa.",
   "license": "MIT",
   "author": "Jake Franklin",
   "homepage": "https://github.com/joeyhage/homebridge-alexa-smarthome#readme",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jakef14/homebridge-alexa-smarthome.git"
+    "url": "git://github.com/joeyhage/homebridge-alexa-smarthome.git"
   },
   "bugs": {
-    "url": "https://github.com/jakef14/homebridge-alexa-smarthome/issues"
+    "url": "https://github.com/joeyhage/homebridge-alexa-smarthome/issues"
   },
   "funding": {
     "type": "github",
-    "url": "https://github.com/sponsors/jakef14"
+    "url": "https://github.com/sponsors/joeyhage"
   },
   "engines": {
     "homebridge": "^1.6.0 || ^2.0.0",

--- a/src/accessory/temperature-accessory.ts
+++ b/src/accessory/temperature-accessory.ts
@@ -6,6 +6,7 @@ import { Service } from 'homebridge';
 import { SupportedActionsType } from '../domain/alexa';
 import { TempSensorState } from '../domain/alexa/temperature-sensor';
 import * as tempMapper from '../mapper/temperature-mapper';
+import * as util from '../util';
 import BaseAccessory from './base-accessory';
 
 export default class TemperatureAccessory extends BaseAccessory {
@@ -36,7 +37,9 @@ export default class TemperatureAccessory extends BaseAccessory {
         O.of(
           this.logWithContext(
             'debug',
-            `Get current temperature result: ${s} Celsius`,
+            `Get current temperature result: ${util.celsiusToFahrenheit(
+              s,
+            )} Fahrenheit`,
           ),
         ),
       ),

--- a/src/accessory/thermostat-accessory.ts
+++ b/src/accessory/thermostat-accessory.ts
@@ -142,7 +142,12 @@ export default class ThermostatAccessory extends BaseAccessory {
       O.flatMap(({ value }) => tempMapper.mapAlexaTempToHomeKit(value)),
       O.tap((s) =>
         O.of(
-          this.logWithContext('debug', `Get current temperature result: ${s}`),
+          this.logWithContext(
+            'debug',
+            `Get current temperature result: ${util.celsiusToFahrenheit(
+              s,
+            )} Fahrenheit`,
+          ),
         ),
       ),
     );
@@ -180,32 +185,7 @@ export default class ThermostatAccessory extends BaseAccessory {
   }
 
   async handleTempUnitsGet(): Promise<number> {
-    const determineTempUnits = flow(
-      A.findFirst<ThermostatState>(
-        ({ featureName }) => featureName === 'temperatureSensor',
-      ),
-      O.tap(({ value }) => {
-        return O.of(
-          this.logWithContext(
-            'debug',
-            `Get temperature units result: ${
-              util.isRecord(value) ? value.scale : 'Unknown'
-            }`,
-          ),
-        );
-      }),
-      O.flatMap(({ value }) =>
-        tempMapper.mapAlexaTempUnitsToHomeKit(value, this.Characteristic),
-      ),
-    );
-
-    return pipe(
-      this.getStateGraphQl(determineTempUnits),
-      TE.match((e) => {
-        this.logWithContext('errorT', 'Get temperature units', e);
-        throw this.serviceCommunicationError;
-      }, identity),
-    )();
+    return this.Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
   }
 
   async handleTargetStateGet(): Promise<number> {
@@ -387,7 +367,9 @@ export default class ThermostatAccessory extends BaseAccessory {
         O.of(
           this.logWithContext(
             'debug',
-            `Get target temperature result: ${s} Celsius`,
+            `Get target temperature result: ${util.celsiusToFahrenheit(
+              s,
+            )} Fahrenheit`,
           ),
         ),
       ),
@@ -467,7 +449,9 @@ export default class ThermostatAccessory extends BaseAccessory {
         O.of(
           this.logWithContext(
             'debug',
-            `Get cooling temperature result: ${s} Celsius`,
+            `Get cooling temperature result: ${util.celsiusToFahrenheit(
+              s,
+            )} Fahrenheit`,
           ),
         ),
       ),
@@ -551,7 +535,9 @@ export default class ThermostatAccessory extends BaseAccessory {
         O.of(
           this.logWithContext(
             'debug',
-            `Get heating temperature result: ${s} Celsius`,
+            `Get heating temperature result: ${util.celsiusToFahrenheit(
+              s,
+            )} Fahrenheit`,
           ),
         ),
       ),

--- a/src/accessory/thermostat-accessory.ts
+++ b/src/accessory/thermostat-accessory.ts
@@ -39,6 +39,8 @@ export default class ThermostatAccessory extends BaseAccessory {
   private isAirConditioner = false;
   private supportsHeat = true;
   private supportsCool = true;
+  // Some mini-split systems (e.g. Mitsubishi Comfort) expose a fan-only mode
+  private supportsFanOnly = true;
 
   configureServices() {
     // Determine AC/thermostat behavior and supported modes before wiring characteristics
@@ -780,6 +782,8 @@ export default class ThermostatAccessory extends BaseAccessory {
     // Defaults if we haven't cached anything yet:
     this.supportsCool = hasUpper || true; // assume cooling is available (safe for mini-splits)
     this.supportsHeat = hasLower || false; // default to no-heat until proven otherwise
+    // Always expose fan-only mode for devices like Mitsubishi mini splits
+    this.supportsFanOnly = true;
 
     // If name clearly indicates AC and we didn’t see heat, force AC-only
     if (this.inferIsAirConditioner() && !hasLower) {
@@ -789,19 +793,28 @@ export default class ThermostatAccessory extends BaseAccessory {
 
     this.logWithContext(
       'debug',
-      `Mode support detected: supportsCool=${this.supportsCool}, supportsHeat=${this.supportsHeat}, isAC=${this.isAirConditioner}`,
+      `Mode support detected: supportsCool=${this.supportsCool}, supportsHeat=${this.supportsHeat}, fanOnly=${this.supportsFanOnly}, isAC=${this.isAirConditioner}`,
     );
   }
 
   /** NEW: restrict HomeKit TargetHeatingCoolingState to supported values */
   private constrainTargetStateProps(): void {
     const C = this.Characteristic.TargetHeatingCoolingState;
-    const valid =
+    const target = C as unknown as { FAN_ONLY?: number };
+    if (typeof target.FAN_ONLY !== 'number') {
+      target.FAN_ONLY = 4;
+    }
+
+    let valid =
       this.supportsHeat && this.supportsCool
         ? [C.OFF, C.HEAT, C.COOL, C.AUTO]
         : this.supportsCool
         ? [C.OFF, C.COOL, C.AUTO]
         : [C.OFF, C.HEAT, C.AUTO];
+
+    if (this.supportsFanOnly) {
+      valid = [...valid, target.FAN_ONLY];
+    }
 
     this.service.getCharacteristic(C).setProps({ validValues: valid });
   }

--- a/src/domain/homebridge/index.ts
+++ b/src/domain/homebridge/index.ts
@@ -24,6 +24,7 @@ export interface AlexaPlatformConfig extends PlatformConfig {
   };
   performance: Nullable<{
     cacheTTL: Nullable<number>;
+    backgroundRefresh: Nullable<boolean>;
   }>;
   debug: Nullable<boolean>;
 }

--- a/src/mapper/index.test.ts
+++ b/src/mapper/index.test.ts
@@ -53,6 +53,31 @@ describe('mapAlexaDeviceToHomeKitAccessoryInfos', () => {
     // then
     expect(lightAcc).toStrictEqual(E.left(new InvalidDeviceError(device)));
   });
+  test('should skip application devices', async () => {
+    // given
+    const device: SmartHomeDevice = {
+      id: '123',
+      endpointId: 'endpoint',
+      displayName: 'app device',
+      supportedOperations: [],
+      enabled: true,
+      deviceType: 'APPLICATION',
+      serialNumber: 'SN',
+      model: 'Model',
+      manufacturer: 'Manufacturer',
+    };
+    const platform = global.createPlatform();
+
+    // when
+    const result = mapper.mapAlexaDeviceToHomeKitAccessoryInfos(
+      platform,
+      randomUUID(),
+      device,
+    );
+
+    // then
+    expect(result).toStrictEqual(E.right([]));
+  });
 
   test('should map switch with brightness capability to light bulb accessory', async () => {
     // given

--- a/src/mapper/index.test.ts
+++ b/src/mapper/index.test.ts
@@ -53,13 +53,13 @@ describe('mapAlexaDeviceToHomeKitAccessoryInfos', () => {
     // then
     expect(lightAcc).toStrictEqual(E.left(new InvalidDeviceError(device)));
   });
-  test('should skip application devices', async () => {
+  test('should map application thermostat to thermostat accessory', async () => {
     // given
     const device: SmartHomeDevice = {
       id: '123',
       endpointId: 'endpoint',
       displayName: 'app device',
-      supportedOperations: [],
+      supportedOperations: ['setTargetSetpoint'],
       enabled: true,
       deviceType: 'APPLICATION',
       serialNumber: 'SN',
@@ -76,7 +76,15 @@ describe('mapAlexaDeviceToHomeKitAccessoryInfos', () => {
     );
 
     // then
-    expect(result).toStrictEqual(E.right([]));
+    expect(result).toStrictEqual(
+      E.right([
+        {
+          altDeviceName: O.none,
+          deviceType: platform.Service.Thermostat.UUID,
+          uuid: global.TEST_UUID,
+        },
+      ]),
+    );
   });
 
   test('should map switch with brightness capability to light bulb accessory', async () => {

--- a/src/mapper/index.ts
+++ b/src/mapper/index.ts
@@ -172,6 +172,7 @@ const determineSupportedHomeKitAccessories = (
         ),
       ),
     )
+    .with(['APPLICATION', Pattern._], () => E.of([]))
     .when(
       ([_, ops]) =>
         supportsRequiredActions(SwitchAccessory.requiredOperations, ops),

--- a/src/mapper/index.ts
+++ b/src/mapper/index.ts
@@ -151,6 +151,19 @@ const determineSupportedHomeKitAccessories = (
           },
         ]),
     )
+    .when(
+      ([type, ops]) =>
+        type === 'APPLICATION' &&
+        supportsRequiredActions(ThermostatAccessory.requiredOperations, ops),
+      () =>
+        E.of([
+          {
+            altDeviceName: O.none,
+            deviceType: platform.Service.Thermostat.UUID,
+            uuid: generateUuid(platform, entityId, device.deviceType),
+          },
+        ]),
+    )
     .with(['ALEXA_VOICE_ENABLED', Pattern._], () =>
       E.of([
         ...echo.toSupportedHomeKitAccessories(
@@ -172,7 +185,6 @@ const determineSupportedHomeKitAccessories = (
         ),
       ),
     )
-    .with(['APPLICATION', Pattern._], () => E.of([]))
     .when(
       ([_, ops]) =>
         supportsRequiredActions(SwitchAccessory.requiredOperations, ops),

--- a/src/mapper/thermostat-mapper.test.ts
+++ b/src/mapper/thermostat-mapper.test.ts
@@ -1,0 +1,21 @@
+import { Characteristic } from 'homebridge';
+import {
+  mapAlexaModeToHomeKit,
+  mapHomekitModeToAlexa,
+} from './thermostat-mapper';
+
+describe('thermostat-mapper fan-only mode', () => {
+  it('maps FAN_ONLY from Alexa to HomeKit', () => {
+    const value = mapAlexaModeToHomeKit('FAN_ONLY', Characteristic);
+    const fanOnly =
+      (Characteristic.TargetHeatingCoolingState as any).FAN_ONLY || 4;
+    expect(value).toBe(fanOnly);
+  });
+
+  it('maps fan-only from HomeKit to Alexa', () => {
+    const fanOnly =
+      (Characteristic.TargetHeatingCoolingState as any).FAN_ONLY || 4;
+    const mode = mapHomekitModeToAlexa(fanOnly, Characteristic);
+    expect(mode).toBe('FAN_ONLY');
+  });
+});

--- a/src/mapper/thermostat-mapper.ts
+++ b/src/mapper/thermostat-mapper.ts
@@ -3,22 +3,47 @@ import type { Characteristic } from 'homebridge';
 import { match } from 'ts-pattern';
 import { CapabilityState } from '../domain/alexa';
 
+/**
+ * Ensure the HomeKit TargetHeatingCoolingState characteristic exposes a
+ * numeric value for a fan-only operating mode. HomeKit only defines OFF, HEAT,
+ * COOL and AUTO, but many HVAC devices (such as Mitsubishi mini splits)
+ * support a "fan only" mode which Alexa exposes as `FAN_ONLY`.  We assign a
+ * constant value of `4` to represent this mode if it has not been defined
+ * previously.
+ */
+const ensureFanOnlyValue = (characteristic: typeof Characteristic): number => {
+  const target = characteristic.TargetHeatingCoolingState as unknown as {
+    FAN_ONLY?: number;
+  };
+  if (typeof target.FAN_ONLY !== 'number') {
+    target.FAN_ONLY = 4;
+  }
+  return target.FAN_ONLY;
+};
+
 export const mapAlexaModeToHomeKit = (
   value: CapabilityState['value'],
   characteristic: typeof Characteristic,
-) =>
-  match(value)
+) => {
+  const fanOnly = ensureFanOnlyValue(characteristic);
+  return match(value)
     .with('HEAT', constant(characteristic.TargetHeatingCoolingState.HEAT))
     .with('COOL', constant(characteristic.TargetHeatingCoolingState.COOL))
     .with('AUTO', constant(characteristic.TargetHeatingCoolingState.AUTO))
+    .with('FAN_ONLY', constant(fanOnly))
     .otherwise(constant(characteristic.TargetHeatingCoolingState.OFF));
+};
 
 export const mapHomekitModeToAlexa = (
   value: number,
   characteristic: typeof Characteristic,
-) =>
-  match(value)
+) => {
+  const fanOnly = ensureFanOnlyValue(characteristic);
+  return match(value)
     .with(characteristic.TargetHeatingCoolingState.OFF, constant('OFF'))
     .with(characteristic.TargetHeatingCoolingState.HEAT, constant('HEAT'))
     .with(characteristic.TargetHeatingCoolingState.COOL, constant('COOL'))
+    .with(characteristic.TargetHeatingCoolingState.AUTO, constant('AUTO'))
+    .with(fanOnly, constant('FAN_ONLY'))
     .otherwise(constant('AUTO'));
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -157,6 +157,9 @@ export const round = (value: number, decimals: number) => {
   return Number(Math.round(Number(value + 'e' + decimals)) + 'e-' + decimals);
 };
 
+export const celsiusToFahrenheit = (value: number) =>
+  round((value * 9) / 5 + 32, 1);
+
 export const isRecord = <T extends string | number | symbol>(
   obj: unknown,
 ): obj is Record<T, unknown> =>

--- a/src/wrapper/alexa-api-wrapper.ts
+++ b/src/wrapper/alexa-api-wrapper.ts
@@ -20,7 +20,7 @@ import {
 import { AlexaApiError, HttpError, TimeoutError } from '../domain/alexa/errors';
 import EndpointStateResponse, {
   extractStates,
-} from '../domain/alexa/get-device-state.js';
+} from '../domain/alexa/get-device-state';
 import GetDeviceStatesResponse, {
   ValidStatesByDevice,
 } from '../domain/alexa/get-device-states';
@@ -33,7 +33,7 @@ import {
 import { extractRangeFeatures } from '../domain/alexa/save-device-capabilities';
 import SetDeviceStateResponse, {
   validateSetStateSuccessful,
-} from '../domain/alexa/set-device-state.js';
+} from '../domain/alexa/set-device-state';
 import DeviceStore from '../store/device-store';
 import { PluginLogger } from '../util/plugin-logger';
 import {


### PR DESCRIPTION
## Summary
- support FAN_ONLY mode in thermostat mapper and accessory
- include tests for new fan-only mapping

## Testing
- `npm test` *(fails: Type '{ cacheTTL: number; backgroundRefresh: false; }' is not assignable to type 'Nullable<{ cacheTTL: Nullable<number>; }>'`*


------
https://chatgpt.com/codex/tasks/task_e_68a0cfd6b8b48326835d7c6c36250a1d