### PR TITLE
Handle missing Alexa states to prevent thermostat errors

### DIFF
--- a/src/domain/alexa/temperature.ts
+++ b/src/domain/alexa/temperature.ts
@@ -3,7 +3,10 @@ import { CapabilityState } from './index';
 export const isTemperatureValue = (
   state: CapabilityState['value'],
 ): state is Temperature =>
-  typeof state === 'object' && 'value' in state && 'scale' in state;
+  state !== null &&
+  typeof state === 'object' &&
+  'value' in state &&
+  'scale' in state;
 
 export type TemperatureScale =
   | 'fahrenheit'


### PR DESCRIPTION
## Summary
- guard temperature parsing against null values
- fall back to cached values when thermostat power/temperature states are missing
- suppress InvalidResponse log noise and use sensor readings when Alexa omits setpoints

## Testing
- `npm test` *(fails: Module 'get-devices' has no default export, missing argument errors, etc.)*
- `npm run lint` *(fails: TypeScript errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d76a1638832689e135b977c86093