### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2025-08-16
+
+### Changed
+- Bump version to 1.0.2.
+
 ## [1.0.1] - 2025-08-16
 
 ### Changed
@@ -261,7 +266,8 @@ See the [roadmap](https://homebridge-alexa-smarthome.canny.io/) for up-to-date, 
 
 - Support for outlets i.e. smart plugs.
 
-[unreleased]: https://github.com/jakef14/homebridge-alexa-smarthome/compare/v1.0.1...HEAD
+[unreleased]: https://github.com/jakef14/homebridge-alexa-smarthome/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/jakef14/homebridge-alexa-smarthome/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/jakef14/homebridge-alexa-smarthome/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/jakef14/homebridge-alexa-smarthome/releases/tag/v1.0.0
 [0.0.15]: https://github.com/jakef14/homebridge-alexa-smarthome/releases/tag/v0.0.15

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-ac-test",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-ac-test",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "alexa-cookie2": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge AC Test",
   "name": "homebridge-ac-test",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Homebridge plugin that can control smart home devices connected to Alexa.",
   "license": "MIT",
   "author": "Jake Franklin",


### PR DESCRIPTION
## Summary
- bump version to 1.0.2
- update changelog

## Testing
- `npm test` *(fails: many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dbdc812c8326b1d50a6db8ff3b34