### PR TITLE
feat: support application device type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Include APPLICATION in supported device types list.
+
 ## [1.0.2] - 2025-08-16
 
 ### Changed

--- a/src/domain/alexa/errors.test.ts
+++ b/src/domain/alexa/errors.test.ts
@@ -1,0 +1,21 @@
+import { UnsupportedDeviceError } from './errors';
+import { SmartHomeDevice } from './get-devices';
+
+describe('UnsupportedDeviceError', () => {
+  test('includes APPLICATION in supported device types', () => {
+    const device: SmartHomeDevice = {
+      id: 'id',
+      endpointId: 'endpoint',
+      displayName: 'name',
+      supportedOperations: [],
+      enabled: true,
+      deviceType: 'OTHER',
+      serialNumber: 'sn',
+      model: 'model',
+      manufacturer: 'manufacturer',
+    };
+
+    const error = new UnsupportedDeviceError(device);
+    expect(error.message).toContain('APPLICATION');
+  });
+});

--- a/src/domain/alexa/index.ts
+++ b/src/domain/alexa/index.ts
@@ -13,6 +13,7 @@ export const SupportedDeviceTypes = [
   'VACUUM_CLEANER',
   'GAME_CONSOLE',
   'AIR_FRESHENER',
+  'APPLICATION',
 ];
 
 export type AmazonDomain =


### PR DESCRIPTION
## Summary
- include APPLICATION in supported device types list
- cover UnsupportedDeviceError for APPLICATION devices

## Testing
- `npm test` *(fails: Module '...get-devices' has no default export, etc.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0de0e18448326af9c7b0c816a3166