### PR TITLE
feat: support application thermostats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See the [roadmap](https://homebridge-alexa-smarthome.canny.io/) for up-to-date, unreleased work in progress.
 
+### Added
+
+- Support for Mitsubishi Comfort mini split devices that appear as applications, treating them as thermostats.
+
 ## [2.3.0] - 2025-04-12
 
 ### Changed

--- a/__tests__/test-setup.ts
+++ b/__tests__/test-setup.ts
@@ -49,7 +49,6 @@ global.createPlatformConfig = (): AlexaPlatformConfig => ({
   },
   performance: {
     cacheTTL: 30,
-    backgroundRefresh: false,
   },
   debug: true,
 });

--- a/src/domain/alexa/index.ts
+++ b/src/domain/alexa/index.ts
@@ -8,6 +8,7 @@ export const SupportedDeviceTypes = [
   'FAN',
   'SMARTPLUG',
   'THERMOSTAT',
+  'APPLICATION',
   'ALEXA_VOICE_ENABLED',
   'AIR_QUALITY_MONITOR',
   'VACUUM_CLEANER',

--- a/src/mapper/index.test.ts
+++ b/src/mapper/index.test.ts
@@ -121,4 +121,38 @@ describe('mapAlexaDeviceToHomeKitAccessoryInfos', () => {
       ]),
     );
   });
+
+  test('should map application thermostat device to thermostat accessory', async () => {
+    // given
+    const device = {
+      id: '123',
+      displayName: 'test mini split',
+      description: 'test',
+      supportedOperations: ['setTargetSetpoint'],
+      providerData: {
+        enabled: true,
+        categoryType: 'APPLIANCE',
+        deviceType: 'APPLICATION',
+      },
+    };
+    const platform = global.createPlatform();
+
+    // when
+    const thermostatAcc = mapper.mapAlexaDeviceToHomeKitAccessoryInfos(
+      platform,
+      randomUUID(),
+      device,
+    );
+
+    // then
+    expect(thermostatAcc).toStrictEqual(
+      E.right([
+        {
+          altDeviceName: O.none,
+          deviceType: platform.Service.Thermostat.UUID,
+          uuid: global.TEST_UUID,
+        },
+      ]),
+    );
+  });
 });

--- a/src/mapper/index.ts
+++ b/src/mapper/index.ts
@@ -140,7 +140,7 @@ const determineSupportedHomeKitAccessories = (
     )
     .when(
       ([type, ops]) =>
-        type === 'THERMOSTAT' &&
+        (type === 'THERMOSTAT' || type === 'APPLICATION') &&
         supportsRequiredActions(ThermostatAccessory.requiredOperations, ops),
       () =>
         E.of([


### PR DESCRIPTION
## Summary
- handle Alexa devices reported as APPLICATION as thermostats
- document Mitsubishi Comfort mini split support
- add coverage for application thermostats

## Testing
- `npm test` *(fails: Cannot find module '../domain/alexa/get-device-state.js' from 'src/wrapper/alexa-api-wrapper.ts')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0e86a8c1483268b90b74cb9aeaead