### PR TITLE
fix: detect thermostat heating support

### DIFF
--- a/src/accessory/thermostat-accessory.test.ts
+++ b/src/accessory/thermostat-accessory.test.ts
@@ -1,0 +1,59 @@
+import * as O from 'fp-ts/Option';
+import * as E from 'fp-ts/Either';
+import { HomebridgeAPI } from 'homebridge/lib/api';
+import AlexaRemote from '../alexa-remote.js';
+import { AlexaSmartHomePlatform } from '../platform';
+import ThermostatAccessory from './thermostat-accessory';
+
+describe('thermostat accessory supported modes', () => {
+  test('exposes HEAT when heating supported', async () => {
+    const device = {
+      id: '123',
+      endpointId: 'endpoint-1',
+      displayName: 'test air conditioner',
+      supportedOperations: ['setTargetSetpoint'],
+      enabled: true,
+      deviceType: 'APPLICATION',
+      serialNumber: 'SN',
+      model: 'Model',
+      manufacturer: 'Manufacturer',
+    };
+
+    const platform = createPlatform();
+    const uuid = platform.HAP.uuid.generate(device.id);
+    const platAcc = new platform.api.platformAccessory(
+      device.displayName,
+      uuid,
+    );
+    const acc = new ThermostatAccessory(platform, device, platAcc);
+    acc.configureServices();
+
+    const C = acc.Characteristic.TargetHeatingCoolingState;
+    expect(acc.service.getCharacteristic(C).props.validValues).not.toContain(
+      C.HEAT,
+    );
+
+    const state = {
+      featureName: 'thermostat',
+      name: 'thermostatMode',
+      value: 'HEAT',
+    } as any;
+    platform.deviceStore.updateCache([device.id], {
+      [device.id]: O.some([E.right(state)]),
+    });
+    (acc as any).detectSupportedModes();
+    (acc as any).constrainTargetStateProps();
+
+    expect(acc.service.getCharacteristic(C).props.validValues).toContain(
+      C.HEAT,
+    );
+  });
+});
+
+function createPlatform(): AlexaSmartHomePlatform {
+  return new AlexaSmartHomePlatform(
+    global.MockLogger,
+    global.createPlatformConfig(),
+    new HomebridgeAPI(),
+  );
+}


### PR DESCRIPTION
## Summary
- infer heating support using current thermostat mode instead of only cached lower setpoint
- refresh supported modes after fetching state
- add test ensuring heaters expose HEAT mode

## Testing
- `npx jest src/accessory/thermostat-accessory.test.ts`
- `npm test` *(fails: Please open http://localhost:2345/ with your browser and login to Amazon. The cookie will be output here after successfull login., Module has no default export, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f7555f30832687b76b3cd0ad4de1