### PR TITLE
Expose heat mode to HomeKit

### DIFF
--- a/src/accessory/thermostat-accessory.ts
+++ b/src/accessory/thermostat-accessory.ts
@@ -46,11 +46,9 @@ export default class ThermostatAccessory extends BaseAccessory {
         this.device.displayName,
       );
 
-    // this.service
-    //   .getCharacteristic(
-    //     this.platform.Characteristic.CurrentHeatingCoolingState,
-    //   )
-    //   .onGet(this.handleCurrentStateGet.bind(this));
+    this.service
+      .getCharacteristic(this.Characteristic.CurrentHeatingCoolingState)
+      .onGet(this.handleCurrentStateGet.bind(this));
 
     this.service
       .getCharacteristic(this.Characteristic.CurrentTemperature)
@@ -149,6 +147,18 @@ export default class ThermostatAccessory extends BaseAccessory {
 
   async handleTempUnitsGet(): Promise<number> {
     return this.Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
+  }
+
+  async handleCurrentStateGet(): Promise<number> {
+    const targetState = await this.handleTargetStateGet();
+    switch (targetState) {
+      case this.Characteristic.TargetHeatingCoolingState.HEAT:
+        return this.Characteristic.CurrentHeatingCoolingState.HEAT;
+      case this.Characteristic.TargetHeatingCoolingState.COOL:
+        return this.Characteristic.CurrentHeatingCoolingState.COOL;
+      default:
+        return this.Characteristic.CurrentHeatingCoolingState.OFF;
+    }
   }
 
   async handleTargetStateGet(): Promise<number> {


### PR DESCRIPTION
## Summary
- expose CurrentHeatingCoolingState so heat option appears in HomeKit
- map HomeKit target state to current state for thermostat

## Testing
- `npm test` *(fails: Module '"/workspace/homebridge-alexa-smarthome/src/domain/alexa/get-devices"' has no default export; many type errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0ff8896948326a304d59f37a70194